### PR TITLE
Use pre-commit hooks for code-formatting

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,33 @@
+---
+BasedOnStyle: Chromium
+AccessModifierOffset: -4
+AllowShortFunctionsOnASingleLine: All
+BreakConstructorInitializers: BeforeColon
+ColumnLimit: 100
+ConstructorInitializerIndentWidth: 8
+ContinuationIndentWidth: 8
+Cpp11BracedListStyle: true
+DerivePointerAlignment: true
+FixNamespaceComments: true
+IncludeBlocks : Regroup
+IncludeCategories:
+  - Regex:    '^"'
+    Priority: 1
+  - Regex:    '^<.*/'
+    Priority: 2
+  - Regex:    '\.h>'
+    Priority: 2
+  - Regex:    '\.hpp>'
+    Priority: 2
+  - Regex:    '\.h\+\+>'
+    Priority: 2
+IncludeIsMainRegex: '(_test|_tests|Tests|Test)?$'
+IndentCaseLabels: false
+IndentWidth: 4
+PointerAlignment: Middle
+ReflowComments: false
+SortIncludes: true
+SortUsingDeclarations: true
+Standard: Cpp11
+
+...

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,12 +23,14 @@ repos:
     rev: 22.3.0
     hooks:
       - id: black
+        exclude: 'dorado/3rdparty/'
         args:
           - '--target-version=py37'
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: 'v13.0.1'
     hooks:
       - id: clang-format
+        exclude: 'dorado/3rdparty/'
 
 # NB: by default, pre-commit only installs the pre-commit hook ("commit" stage),
 # but you can tell `pre-commit install` to install other hooks.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,42 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.0.1
+    hooks:
+      - id: check-case-conflict
+      - id: check-merge-conflict
+
+      # TODO: consider enabling these in the future (will want to rewrite a lot of files right now)
+      #- id: end-of-file-fixer
+      #- id: mixed-line-ending
+      #- id: trailing-whitespace
+
+      # TODO: consider this (will need to change dev_tools/release/helpers.py to skip hooks):
+      #- id: no-commit-to-branch
+      #  args:
+      #    - '--branch=develop'
+      #    - '--pattern=release/.*'
+      #  stages:
+      #    - commit
+  - repo: https://github.com/psf/black
+    rev: 22.3.0
+    hooks:
+      - id: black
+        args:
+          - '--target-version=py37'
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: 'v13.0.1'
+    hooks:
+      - id: clang-format
+
+# NB: by default, pre-commit only installs the pre-commit hook ("commit" stage),
+# but you can tell `pre-commit install` to install other hooks.
+# This set of default stages ensures we don't slow down or break other git operations
+# even if you install hooks for them.
+default_stages:
+  - commit
+  - merge-commit
+  - manual
+
+# vi:et:sw=2:sts=2:

--- a/README.md
+++ b/README.md
@@ -46,3 +46,16 @@ Other Platforms may work, if you encounter problems with running on your system 
 * Multi-GPU support is limited and likely not to work.
 * GPU memory utilisation on Nvidia devices is high (compared to [Bonito](https://github.com/nanoporetech/bonito)). This issue is currently being investigated and resolved.
 * Support for M1 GPUs is should be considered experimental.
+
+### Pre commit
+
+The project uses pre-commit to ensure code is consistently formatted, you can set this up using pip:
+
+```bash
+> pip install pre-commit
+# Install pre-commit hooks in your dorado repo:
+> cd dorado
+> pre-commit install
+# Run hooks on all files:
+> pre-commit run --all-files
+```


### PR DESCRIPTION
Now using the same approach as [pod5-file-format](https://github.com/nanoporetech/pod5-file-format) for code formatting. 

I will push the formatted source files after review of the changes. Also, should the `3rdparty` folder be excluded from code formatting? 

Cheers! 
Lotfi 