### PR TITLE
A fix for int overflow issue

### DIFF
--- a/dorado/read_pipeline/WriterNode.cpp
+++ b/dorado/read_pipeline/WriterNode.cpp
@@ -33,6 +33,9 @@ void WriterNode::worker_thread() {
         m_reads.pop_front();
         lock.unlock();
 
+        if (m_num_samples_processed > std::numeric_limits<std::int64_t>::max() - read->raw_data.size(0)) {
+            EXIT_FAILURE;
+        }
         m_num_samples_processed += read->raw_data.size(0);
         m_num_reads_processed += 1;
 

--- a/dorado/read_pipeline/WriterNode.h
+++ b/dorado/read_pipeline/WriterNode.h
@@ -18,7 +18,7 @@ private:
     // Emit Fastq if true
     bool m_emit_fastq;
     // Total number of raw samples from the read WriterNode has processed. Used for performance benchmarking and debugging.
-    int m_num_samples_processed;
+    int64_t m_num_samples_processed;
     //Total number of reads WriterNode has processed
     int m_num_reads_processed;
     // Time when Node is initialised.


### PR DESCRIPTION
Hello,

I think it is better to use a different datatype for `m_num_samples_processed` than `int`.

Thank you.