### PR TITLE
Fix README.md problems

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,13 +120,19 @@ apt-get update && \
 ```
 
 ### Clone and build
+The commands below will build dorado and install it in `/opt`.
+ `NUM_THREADS` controls the number of threads that cmake uses to compile dorado. It can be set to a value higher than "1", but using too many threads can use all available RAM and cause compilation to fail. Peak memory usage seems to be 1-2GB per thread.
 
 ```
-$ git clone git@github.com:nanoporetech/dorado.git
-$ cd dorado
-$ cmake -S . -B cmake-build -DCMAKE_CUDA_COMPILER=<NVCC_DIR>/nvcc
-$ cmake --build cmake-build --config Release -j
-$ ctest --test-dir cmake-build
+export NUM_THREADS=1
+git clone https://github.com/nanoporetech/dorado.git /dorado
+cd /dorado
+cmake -S . -B cmake-build -DCMAKE_CUDA_COMPILER=nvcc
+cmake --build cmake-build --config Release --parallel $NUM_THREADS
+ctest --test-dir cmake-build
+cmake --install cmake-build --prefix /opt
+rm -rf /dorado
+cd /
 ```
 
 ### Pre commit

--- a/README.md
+++ b/README.md
@@ -102,9 +102,21 @@ The following models are currently available:
 ## Developer quickstart
 
 ### Linux dependencies
-
+The following packages are necessary to build dorado in a barebones environment (e.g. the official ubuntu:jammy docker image)
 ```
-apt-get update && apt-get install -y --no-install-recommends libhdf5-dev libssl-dev libzstd-dev
+apt-get update && \
+    apt-get install -y --no-install-recommends \
+        curl \
+        git \
+        ca-certificates \
+        build-essential \
+        nvidia-cuda-toolkit \
+        libhdf5-dev \
+        libssl-dev \
+        libzstd-dev \
+        cmake \
+        autoconf \
+        automake
 ```
 
 ### Clone and build


### PR DESCRIPTION
The previous build instructions have problems that prevent building dorado from source.

These tweaks make it possible to build dorado in a "clean" environment (a minimal ubuntu:jammy docker image).

The problems fixed are:
1. Several packages are necessary in addition to those lists in the previous version of instructions. These would probably already be installed on a standard server, but are missing in a minimal linux environment.
2. The original git clone uses an SSH URL, which requires being a member of the repo. I have switched to the HTTPS URL.
3. The original command includes `<NVCC_DIR>` without instructions to replace this with the path to `nvcc`. These instructions should work fine as long as the directory containing `nvcc` are in $PATH
4. The original command give the `-j` flag without any argument to `cmake --build` which seems to use as many threads as possible. This failed due to maxing out memory on my machine with 20GB RAM.
5. Added step to install in /opt
6. Added step to clean up after building and installing.

Using these modified instructions I have successfully built a Singularity image with dorado compiled from source, bootstrapped ona minimal ubuntu:jammy image. I am happy to share the Singularity recipe file and the built image.