### PR TITLE
Cppcheck found array out-of-bounds at line 129.

### DIFF
--- a/dorado/utils/tensor_utils.cpp
+++ b/dorado/utils/tensor_utils.cpp
@@ -125,7 +125,7 @@ torch::Tensor quantile_counting(const torch::Tensor t, const torch::Tensor q) {
 
     for (size_t idx = 0; idx < q.numel(); idx++) {
         int threshold = q[idx].item<float>() * (size - 1);
-        for (int i = 0; i <= counts.size(); ++i) {
+        for (int i = 0; i < counts.size(); ++i) {
             if (counts[i] > threshold) {
                 res[idx] = i + range_min;
                 break;


### PR DESCRIPTION
tensor_utils.cpp
error: Out of bounds access in expression 'counts[i]' 
error: When i==counts.size(), counts[i] is out of bounds. 
Fixed loop counter.