### PR TITLE
Add ModelInfo structure for kit 10.4.1 4kHz 260bps data

### DIFF
--- a/dorado/models/models.cpp
+++ b/dorado/models/models.cpp
@@ -440,6 +440,12 @@ const std::vector<ModelInfo> models = {
         ModelInfo{
                 "dna_r10.4.1_e8.2_4khz_stereo@v1.1",
                 "d434525cbe1fd00adbd7f8a5f0e7f0bf09b77a9e67cd90f037c5ab52013e7974",
+                CC::DNA_R10_4_1_E8_2_260BPS,
+                ModelVariantPair{ModelVariant::NONE, VV::NONE},
+        },
+        ModelInfo{
+                "dna_r10.4.1_e8.2_4khz_stereo@v1.1",
+                "d434525cbe1fd00adbd7f8a5f0e7f0bf09b77a9e67cd90f037c5ab52013e7974",
                 CC::DNA_R10_4_1_E8_2_400BPS_4KHZ,
                 ModelVariantPair{ModelVariant::NONE, VV::NONE},
         },


### PR DESCRIPTION
As far as I can tell the stereo model for 260 bps data @ 4kHz is the same as the model for 400 bps model. Unfortunately there is no way to explicitly specify duplex models and increased error checking means you cannot currently stereo basecall your 260 bps data. Therefore I suggest adding a ModelInfo so that this is again possible? If I've got this wrong please do point me in the right direction.