### PR TITLE
add missing include for stream (required for std::ofstream)

### DIFF
--- a/dorado/cli/demux.cpp
+++ b/dorado/cli/demux.cpp
@@ -17,6 +17,7 @@
 #include <spdlog/spdlog.h>
 
 #include <chrono>
+#include <fstream>
 #include <memory>
 #include <optional>
 #include <string>

--- a/dorado/cli/duplex.cpp
+++ b/dorado/cli/duplex.cpp
@@ -39,6 +39,7 @@
 #include <cstdlib>
 #include <exception>
 #include <filesystem>
+#include <fstream>
 #include <memory>
 #include <thread>
 #include <unordered_set>


### PR DESCRIPTION
fix for compilation error with GCC 12.3.0:

```
error: variable std::ofstream summary_out has initializer but incomplete type
```

Note: to make the build of dorado 0.6.1 fully work with GCC 12.3.0, I also had to use `-Wno-error`, see also #779