### PR TITLE
Additional options for poly(A) lengths 

### DIFF
--- a/dorado/poly_tail/poly_tail_calculator.cpp
+++ b/dorado/poly_tail/poly_tail_calculator.cpp
@@ -259,14 +259,14 @@ std::pair<int, int> PolyTailCalculator::determine_signal_bounds(int signal_ancho
     return std::make_pair(best_interval->start, best_interval->end);
 }
 
-int PolyTailCalculator::calculate_num_bases(const SimplexRead& read,
+PolyTailLengthInfo PolyTailCalculator::calculate_num_bases(const SimplexRead& read,
                                             const SignalAnchorInfo& signal_info) const {
     spdlog::trace("{} Strand {}; poly A/T signal anchor {}", read.read_common.read_id,
                   signal_info.is_fwd_strand ? '+' : '-', signal_info.signal_anchor);
 
     auto [num_samples_per_base, stddev] = estimate_samples_per_base(read);
     if (num_samples_per_base == 0) {
-        return 0;
+        return {0, 0, 0};
     }
 
     // Walk through signal. Require a minimum of length 10 poly-A since below that
@@ -289,7 +289,7 @@ int PolyTailCalculator::calculate_num_bases(const SimplexRead& read,
             signal_end, signal_len, num_samples_per_base, read.read_common.num_trimmed_samples,
             read.read_common.seq.length());
 
-    return num_bases;
+    return {num_bases,signal_start,signal_end};
 }
 
 std::shared_ptr<const PolyTailCalculator> PolyTailCalculatorFactory::create(

--- a/dorado/poly_tail/poly_tail_calculator.h
+++ b/dorado/poly_tail/poly_tail_calculator.h
@@ -28,6 +28,16 @@ struct SignalAnchorInfo {
     bool split_tail = false;
 };
 
+struct PolyTailLengthInfo {
+
+    // the length of polyA/T tail (or -1 on failure)
+    int num_bases = -1;
+    // the start of the polyA/T tail in the raw signal
+    int signal_start = -1;
+    // the end of the polyA/T tail in the raw signal
+    int signal_end = -1;
+};
+
 class PolyTailCalculator {
 public:
     PolyTailCalculator(PolyTailConfig config, float speed_calibration, float offset_calibration)
@@ -40,8 +50,8 @@ public:
     // returns information about the polyA/T tail. signal_anchor = -1 on failure
     virtual SignalAnchorInfo determine_signal_anchor_and_strand(const SimplexRead& read) const = 0;
 
-    // returns the number of bases in the polyA/T tail, or -1 on failure
-    int calculate_num_bases(const SimplexRead& read, const SignalAnchorInfo& signal_info) const;
+    // returns the array with: number of bases in the polyA/T tail () or -1 on failure), and start and end of poly(A) in raw signal 
+    virtual PolyTailLengthInfo calculate_num_bases(const SimplexRead& read, const SignalAnchorInfo& signal_info) const;
 
     static int max_tail_length() { return 750; };
 

--- a/dorado/read_pipeline/messages.cpp
+++ b/dorado/read_pipeline/messages.cpp
@@ -115,6 +115,13 @@ void ReadCommon::generate_read_tags(bam1_t *aln, bool emit_moves, bool is_duplex
     if (rna_poly_tail_length != ReadCommon::POLY_TAIL_NOT_ENABLED) {
         bam_aux_append(aln, "pt", 'i', sizeof(rna_poly_tail_length),
                        (uint8_t *)&rna_poly_tail_length);
+
+        if (polya_signal_boundaries.first != -1 && polya_signal_boundaries.second != -1) {
+            // Store the start and end of the polyA/T tail in the signal (if found) in the ps:i: tag
+            std::string pts = std::to_string(polya_signal_boundaries.first) + "," + 
+                              std::to_string(polya_signal_boundaries.second);
+            bam_aux_append(aln, "ps", 'Z', int(pts.length() + 1), (uint8_t *)pts.c_str());
+        }
     }
 }
 

--- a/dorado/read_pipeline/messages.h
+++ b/dorado/read_pipeline/messages.h
@@ -122,6 +122,11 @@ public:
     // where the adapter ends.
     int rna_adapter_end_signal_pos{0};
 
+    // Track the position of the polyA tail in signal space. This is used to
+    // determine the position of the polyA tail in the read.
+    // and can be used for debugging the polyA estimations
+    std::pair<int, int> polya_signal_boundaries{};
+
     // subread_id is used to track 2 types of offsprings of a read
     // (1) read splits
     // (2) duplex pairs which share this read as the template read

--- a/dorado/summary/summary.h
+++ b/dorado/summary/summary.h
@@ -15,6 +15,7 @@ public:
     static constexpr FieldFlags GENERAL_FIELDS = 1;
     static constexpr FieldFlags BARCODING_FIELDS = 2;
     static constexpr FieldFlags ALIGNMENT_FIELDS = 4;
+    static constexpr FieldFlags POLYA_FIELDS = 8;
 
     SummaryData();
     SummaryData(FieldFlags flags);


### PR DESCRIPTION
Two simple additions:
- reporting of polyA boundaries in raw signal, as requested in #1235 
- reporting of polyA lengths (and signal boundaries) in dorado summary output, as requested in #881 