### PR TITLE
Fix demux crash when `-o` is missed

### DIFF
--- a/dorado/cli/cli_lib/demux.cpp
+++ b/dorado/cli/cli_lib/demux.cpp
@@ -180,7 +180,7 @@ int demuxer(int argc, char* argv[]) {
     }
 
     const std::string reads(parser.get<std::string>("reads"));
-    const std::string output_dir = cli::get_output_dir(parser).value();
+    const std::string output_dir = cli::get_output_dir(parser).value_or(".");
     const bool recursive_input(parser.get<bool>("recursive"));
     const bool emit_fastq = cli::get_emit_fastq(parser);
     const bool emit_summary = cli::get_emit_summary(parser);


### PR DESCRIPTION
Fix #1537, the issue that running `dorado demux` without specifying `-o` results in `std::bad_optional_access`.

Previous logic attempted to access `-o` value using `.value()` without checking `.has_value()`.
Now `.value()` is replaced with `.value_or(".")`

Compiled successfully and verified that `dorado demux` runs without `-o` and writes to the current directory.